### PR TITLE
Remove logic to skip PowerShellAccessControl module

### DIFF
--- a/DSCResources/RS_rsModuleZipSum/RS_rsModuleZipSum.psm1
+++ b/DSCResources/RS_rsModuleZipSum/RS_rsModuleZipSum.psm1
@@ -56,9 +56,7 @@ Function Set-TargetResource {
                 $moduleName = $($module, '_', $(((Get-Content -Path $((Join-Path $modulePath -ChildPath $module), $($module, ".psd1" -join '') -join '\')) -match "ModuleVersion") -replace 'ModuleVersion', '' -replace ' ', '' -replace '=', '' -replace "'", '' -replace '"', '').Trim() -join '')
                 if(!(Test-Path -Path $(Join-Path $destination -ChildPath $($moduleName, '.zip' -join ''))) -or !($((Get-FileHash -Path $(Join-Path $destination -ChildPath $($moduleName, '.zip' -join '')) -ErrorAction SilentlyContinue).Hash) -eq $(Get-Content -Path $(Join-Path $destination -ChildPath $($moduleName, '.zip.checksum' -join '')) -ErrorAction SilentlyContinue))) {
                     Remove-Item -Path $((Join-Path $destination -ChildPath $module), '*' -join '') -Force
-                    if($module -ne "PowerShellAccessControl") {
-                        New-ResourceZip -modulePath $(Join-Path $modulePath -ChildPath $module) -outputDir $destination
-                    }
+                    New-ResourceZip -modulePath $(Join-Path $modulePath -ChildPath $module) -outputDir $destination
                 }
             }
         }

--- a/rsPackageSourceManager.psd1
+++ b/rsPackageSourceManager.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '1.0.3'
+ModuleVersion = '1.0.4'
 
 # ID used to uniquely identify this module
 GUID = '28a61e12-3cec-4deb-938e-d20740b586dc'


### PR DESCRIPTION
Removing code to skip "PowerShellAccessControl" module zip archive creation.

closes issue #15 
